### PR TITLE
Fix quotes around -framework Cocoa

### DIFF
--- a/FindSDL2.cmake
+++ b/FindSDL2.cmake
@@ -274,7 +274,7 @@ if(SDL2_LIBRARY)
   # So I use a temporary variable until the end so I can set the
   # "real" variable in one-shot.
   if(APPLE)
-    set(SDL2_LIBRARIES ${SDL2_LIBRARIES} "-framework Cocoa")
+    set(SDL2_LIBRARIES ${SDL2_LIBRARIES} -framework Cocoa)
   endif()
 
   # For threads, as mentioned Apple doesn't need this.
@@ -343,7 +343,7 @@ if(SDL2_FOUND)
       # For OS X, SDL2 uses Cocoa as a backend so it must link to Cocoa.
       # For more details, please see above.
       set_property(TARGET SDL2::Core APPEND PROPERTY
-                   INTERFACE_LINK_OPTIONS "-framework Cocoa")
+                   INTERFACE_LINK_OPTIONS -framework Cocoa)
     else()
       # For threads, as mentioned Apple doesn't need this.
       # For more details, please see above.


### PR DESCRIPTION
On my config, clang return an error while using `FindSDL2.cmake`
`clang: error: unknown argument: '-framework Cocoa'`
It looks like it fails to parse the argument, removing the quotes fix this.
Also are you sure the Cocoa dependency is still needed ? I noticed that apps would still build and run when completely removing the Cocoa dependency.

> OSX 10.12.6
> Apple LLVM version 9.0.0 (clang-900.0.39.2)
> Target: x86_64-apple-darwin16.7.0