### PR TITLE
Fix Windows target (Threads package checking)

### DIFF
--- a/FindSDL2.cmake
+++ b/FindSDL2.cmake
@@ -236,8 +236,8 @@ endif()
 # frameworks may already provide it.
 # But for non-OSX systems, I will use the CMake Threads package.
 if(NOT APPLE)
-  find_package(Threads QUIET)
-  if(NOT CMAKE_THREAD_LIBS_INIT)
+  find_package(Threads)
+  if(NOT Threads_FOUND)
     set(SDL2_THREADS_NOT_FOUND "Could NOT find Threads (Threads is required by SDL2).")
     if(SDL2_FIND_REQUIRED)
       message(FATAL_ERROR ${SDL2_THREADS_NOT_FOUND})

--- a/FindSDL2.cmake
+++ b/FindSDL2.cmake
@@ -236,7 +236,7 @@ endif()
 # frameworks may already provide it.
 # But for non-OSX systems, I will use the CMake Threads package.
 if(NOT APPLE)
-  find_package(Threads)
+  find_package(Threads QUIET)
   if(NOT Threads_FOUND)
     set(SDL2_THREADS_NOT_FOUND "Could NOT find Threads (Threads is required by SDL2).")
     if(SDL2_FIND_REQUIRED)


### PR DESCRIPTION
This changes how the success check for `find_package(Threads ...)` is done.  Despite the possible implications of the [documentation](https://cmake.org/cmake/help/latest/module/FindThreads.html), it seems it's possible for `CMAKE_THREAD_LIBS_INIT` to *not* be set.  Indeed, the caption actually only states it will be set to the thread library.

It appears when building with sanitizers (on clang, linux x86_64, at least?), e.g. `-fsanitize=address,undefined`, that Threads will be successfully found, but there is no library, thus testing this variable (incorrectly) fails.